### PR TITLE
Fix amend button permissions

### DIFF
--- a/app/cells/decidim/proposals/participatory_text_proposal/buttons.erb
+++ b/app/cells/decidim/proposals/participatory_text_proposal/buttons.erb
@@ -1,0 +1,33 @@
+<div class="columns mediumlarge-4 hidden-section p-sm">
+  <div class="medium-8">
+    <%= follow_button_for(model, true) %>
+    <% if amendmendment_creation_enabled? || visible_emendations.any? %>
+      <div class="button-group button-group--collapse mb-s row collapse amend-buttons">
+        <%= link_to resource_amendments_path, class: "column medium-4 button light secondary" do %>
+          <%= visible_emendations.count %>
+        <% end %>
+        <%= action_authorized_link_to :amend, amend_resource_path, resource: model, data: { "redirect_url" => amend_resource_path }, class: "column button hollow secondary button--sc", disabled: amend_button_disabled? do %>
+          <%= t("amend", scope: "decidim.proposals.participatory_text_proposal.buttons") %>
+        <% end %>
+      </div>
+    <% end %>
+    <% if component_settings.comments_enabled? %>
+      <div class="button-group button-group--collapse row collapse comment-buttons">
+        <% if current_settings.comments_blocked? %>
+          <%= content_tag :button, class: "column medium-4 button light secondary" do %>
+            <%= icon "comment-square", class: "icon--small", aria_label: t("comments", scope: "decidim.proposals.participatory_text_proposal.buttons"), role: "img" %>
+            <%= model.comments_count %>
+          <% end %>
+          <%= content_tag :button, t("comment", scope: "decidim.proposals.participatory_text_proposal.buttons"), class: "column button hollow secondary button--sc disabled", disabled: true, title: t("comment", scope: "decidim.proposals.participatory_text_proposal.buttons") %>
+        <% else %>
+          <%= link_to resource_comments_path, class: "column medium-4 button light secondary" do %>
+            <%= icon "comment-square", class: "icon--small", aria_label: t("comments", scope: "decidim.proposals.participatory_text_proposal.buttons"), role: "img" %> <%= model.comments_count %>
+          <% end %>
+          <%= action_authorized_link_to :comment, resource_comments_path, resource: model, class: "column button hollow secondary button--sc" do %>
+            <%= t("comment", scope: "decidim.proposals.participatory_text_proposal.buttons") %>
+          <% end %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -5,3 +5,6 @@ locales: [en]
 
 ignore_missing:
   - decidim.proposals.proposals.participatory_texts.index.document_index
+  - decidim.proposals.participatory_text_proposal.buttons.amend
+  - decidim.proposals.participatory_text_proposal.buttons.comments
+  - decidim.proposals.participatory_text_proposal.buttons.comment

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "spec_helper"
+require "rails_helper"
 
 # We make sure that the checksum of the file overriden is the same
 # as the expected. If this test fails, it means that the overriden
@@ -21,6 +21,7 @@ checksums = [
   {
     package: "decidim-proposals",
     files: {
+      "/app/cells/decidim/proposals/participatory_text_proposal/buttons.erb" => "0810f2a8eebf476b67632227a5c73ff2",
       "/app/cells/decidim/proposals/participatory_text_proposal/show.erb" => "a6fd0029e01e712314f555a9397485f8",
       "/app/views/decidim/proposals/proposals/participatory_texts/_index.html.erb" => "6d3666c3c116689bae657da537d9deef"
     }


### PR DESCRIPTION
The "amend" button in the list of proposals after importing from participatory texts doesn't follow the configured permissions allowing every user to amend the proposal even when they have no permission.

<img width="1059" alt="Screenshot 2023-12-20 at 17 33 06" src="https://github.com/Platoniq/participa-aneca/assets/6973564/fa979bff-2b45-40bd-a7ab-9c3ca24f21c5">

It's a decidim bug, but we have monkey-patched it here to fix it ASAP, and we will work on a fix for decidim anytime soon.
