### PR TITLE
Change schedule to update data portability to download your data task

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -5,6 +5,6 @@ every "30 1 * * *" do
 end
 
 every "3 3 * * *" do
-  rake "decidim:delete_data_portability_files"
+  rake "decidim:delete_download_your_data_files"
   rake "decidim:open_data:export"
 end


### PR DESCRIPTION
Based on  Rename data portability to download your data [#9196](https://github.com/decidim/decidim/pull/9196) we should change the cron task to be executed from `Decidim::delete_data_portability_files` to `decidim:delete_download_your_data_files`

This task is not being executed since that task no longer exists for decidim 0.27