### PR TITLE
add output log in whenever schedule

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+set :output, "log/cron.log"
+
 every "30 1 * * *" do
   rake "decidim:metrics:all"
 end


### PR DESCRIPTION
This PR will add redirections to the output of the cron jobs based on [this](https://github.com/javan/whenever/wiki/Output-redirection-aka-logging-your-cron-jobs)

